### PR TITLE
Suggested fix for chunks that have constructed response items in final chunk

### DIFF
--- a/apps/example-poe/src/components/context/qa-context.tsx
+++ b/apps/example-poe/src/components/context/qa-context.tsx
@@ -2,11 +2,13 @@
 
 import { useCurrentChunk } from "@/lib/hooks/utils";
 import React from "react";
+import { useState } from 'react';
 
 type QAContextType = {
 	currentChunk: string;
 	goToNextChunk: () => void;
 	chunks: string[];
+	finishedReading: boolean;
 };
 
 const QAContext = React.createContext<QAContextType>({} as QAContextType);
@@ -25,6 +27,7 @@ export const QAProvider = ({ children, pageSlug, chunks }: Props) => {
 
 	const goToNextChunk = () => {
 		const currentIndex = chunks.indexOf(currentChunk);
+
 		if (currentIndex + 1 < chunks.length) {
 			setCurrentChunk(chunks[currentIndex + 1]);
 		} else if (currentIndex + 1 >= chunks.length) {
@@ -39,6 +42,7 @@ export const QAProvider = ({ children, pageSlug, chunks }: Props) => {
 				currentChunk,
 				goToNextChunk,
 				chunks,
+				finishedReading,
 			}}
 		>
 			{children}

--- a/apps/example-poe/src/components/context/qa-context.tsx
+++ b/apps/example-poe/src/components/context/qa-context.tsx
@@ -20,11 +20,16 @@ type Props = {
 
 export const QAProvider = ({ children, pageSlug, chunks }: Props) => {
 	const [currentChunk, setCurrentChunk] = useCurrentChunk(pageSlug, chunks[0]);
+	// new context state to keep track of whether a user clicked on the final Next Chunk button within a page
+	const [finishedReading, setFinishedReading] = useState(false);
 
 	const goToNextChunk = () => {
 		const currentIndex = chunks.indexOf(currentChunk);
 		if (currentIndex + 1 < chunks.length) {
 			setCurrentChunk(chunks[currentIndex + 1]);
+		} else if (currentIndex + 1 >= chunks.length) {
+			// set finished reading to true if user clicked on the final Next Chunk button within the page
+			setFinishedReading(true);
 		}
 	};
 

--- a/apps/example-poe/src/components/question/question-control.tsx
+++ b/apps/example-poe/src/components/question/question-control.tsx
@@ -24,7 +24,7 @@ export const QuestionControl = ({
 }: Props) => {
 	// Ref for current chunk
 	const [nodes, setNodes] = useState<JSX.Element[]>([]);
-	const { currentChunk, chunks } = useQA();
+	const { currentChunk, chunks, finishedReading } = useQA();
 
 	const addNode = (node: JSX.Element) => {
 		setNodes((nodes) => [...nodes, node]);
@@ -113,6 +113,16 @@ export const QuestionControl = ({
 		);
 	};
 
+	const hideEnableSummaryButton = () => {
+		const button = document.querySelector(
+			".enable-summary-button-container",
+		) as HTMLDivElement;
+
+		if (button) {
+			button.remove();
+		}
+	};
+
 	const insertQuestion = (el: HTMLDivElement, chunkId: string) => {
 		const questionContainer = document.createElement("div");
 		questionContainer.className = "question-container";
@@ -186,6 +196,7 @@ export const QuestionControl = ({
 		if (idx === chunks.length - 1) {
 			hideScrollBackButton();
 		}
+
 	};
 
 	useEffect(() => {
@@ -197,6 +208,12 @@ export const QuestionControl = ({
 			handleChunkProgress(currentChunk);
 		}
 	}, [currentChunk]);
+
+	useEffect(() => {
+		if (finishedReading){
+			hideEnableSummaryButton();
+		}
+	}, [finishedReading]);
 
 	return nodes;
 };

--- a/apps/example-poe/src/components/question/question-control.tsx
+++ b/apps/example-poe/src/components/question/question-control.tsx
@@ -89,6 +89,30 @@ export const QuestionControl = ({
 		);
 	};
 
+	// separate button for enabling summaries
+	const insertEnableSummaryButton = (el: HTMLDivElement) => {
+		// insert button container
+		const buttonContainer = document.createElement("div");
+		buttonContainer.className =
+			"enable-summary-button-container flex justify-center items-center p-4 gap-2";
+		el.style.filter = "none";
+		el.appendChild(buttonContainer);
+
+		addNode(
+			createPortal(
+				<NextChunkButton
+					clickEventType="chunk reveal"
+					pageSlug={pageSlug}
+					standalone
+					className="bg-violet-400 hover:bg-violet-200 text-white m-2 p-2"
+				>
+					Click here to enable summary
+				</NextChunkButton>,
+				buttonContainer,
+			),
+		);
+	};
+
 	const insertQuestion = (el: HTMLDivElement, chunkId: string) => {
 		const questionContainer = document.createElement("div");
 		questionContainer.className = "question-container";
@@ -148,6 +172,9 @@ export const QuestionControl = ({
 			currentChunkElement.style.filter = "none";
 			if (!selectedQuestions.has(currentChunkId) && idx !== chunks.length - 1) {
 				insertNextChunkButton(currentChunkElement);
+			} else if (!selectedQuestions.has(currentChunkId) && idx === chunks.length - 1) {
+				// insert enable summary button if the chunk is the final chunk and does not have an accompanying question
+				insertEnableSummaryButton(currentChunkElement);
 			}
 		}
 

--- a/apps/example-poe/src/components/summary/summary-form.tsx
+++ b/apps/example-poe/src/components/summary/summary-form.tsx
@@ -39,8 +39,8 @@ export const SummaryForm = ({
 }: Props) => {
 	const [formState, formAction] = useFormState(onSubmit, initialState);
 	const router = useRouter();
-	const { currentChunk, chunks } = useQA();
-	const isLastChunk = currentChunk === chunks[chunks.length - 1];
+	const { currentChunk, chunks, finishedReading } = useQA();
+	const isLastChunk = finishedReading;
 	const [inputDisabled, setInputDisabled] = useState(() => {
 		if (pageStatus.isPageUnlocked) {
 			return false;

--- a/apps/example-poe/src/components/summary/summary-form.tsx
+++ b/apps/example-poe/src/components/summary/summary-form.tsx
@@ -52,7 +52,7 @@ export const SummaryForm = ({
 		if (!pageStatus.isPageUnlocked && inputDisabled) {
 			setInputDisabled(!isLastChunk);
 		}
-	}, [currentChunk]);
+	}, [currentChunk, finishedReading]);
 
 	useEffect(() => {
 		if (formState.showQuiz) {


### PR DESCRIPTION
________
**I don't have the necessary env vars for the newest strapi branch so I have not been able to test this. Needs to be verified if this works before merging** 
________

Currently,  if the last chunk spawns a constructed response item, users can just proceed to writing the summary without having to answer it. Like so:

![image](https://github.com/learlab/itell-strapi-demo/assets/57017670/1dcbb639-2501-455d-8e8c-fcef62562cbe)

The suggested fix that involves minimal changes is to add a boolean, "finishedReading" state to the useQA context, and to add a button in the final chunk that needs to be clicked for user to switch this value to `true` and to enable summary. The "continue reading" button will serve this function if the final chunk has an accompanying constructed response item.