### PR TITLE
Fix page Table of Contents

### DIFF
--- a/apps/cornell/src/components/page-toc.tsx
+++ b/apps/cornell/src/components/page-toc.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { cn } from "@itell/core/utils";
 import { BookmarkIcon } from "lucide-react";
+import { useEffect } from "react";
 
 type Heading = {
 	level: "one" | "two" | "three" | "four" | "other";
@@ -11,14 +14,50 @@ type TocSidebarProps = {
 };
 
 export const PageToc = ({ headings }: TocSidebarProps) => {
+	useEffect(() => {
+		if (typeof window !== "undefined") {
+			window.addEventListener("DOMContentLoaded", () => {
+				const observer = new IntersectionObserver((entries) => {
+					entries.forEach((entry) => {
+						const id = entry.target.id;
+						if (entry.intersectionRatio > 0) {
+							document
+								.querySelector(`div.page-toc ol li a[href="#${id}"]`)
+								?.classList.remove("border-transparent");
+						} else {
+							document
+								.querySelector(`div.page-toc ol li a[href="#${id}"]`)
+								?.classList.add("border-transparent");
+						}
+					});
+				});
+
+				// Track all sections that have an `id` applied
+				document
+					.querySelectorAll("div[data-subsection-id]")
+					.forEach((section) => {
+						const renamedId = section.getAttribute("data-subsection-id");
+						if (renamedId) {
+							const lowercaseId = renamedId.toLowerCase();
+							const slicedId = lowercaseId.split("-").slice(0, -1).join("-");
+							if (headings.map((heading) => heading.slug).includes(slicedId)) {
+								section.id = slicedId;
+								observer.observe(section);
+							}
+						}
+					});
+			});
+		}
+	}, [headings]);
+
 	return (
-		<div>
-			<p className="font-medium flex items-center pb-5">
+		<div className="page-toc">
+			<p className="font-medium flex items-center pb-2">
 				<BookmarkIcon className="mr-2 size-4" />
 				<span>ON THIS PAGE</span>
 			</p>
 
-			<ol className="max-h-[60vh] overflow-y-scroll list-disc mt-2 space-y-2 pl-4 list-none">
+			<ol className="max-h-[60vh] overflow-y-scroll list-disc mt-2 space-y-2 list-none">
 				{headings
 					.filter((heading) => heading.level !== "other")
 					.map((heading) => (
@@ -26,14 +65,17 @@ export const PageToc = ({ headings }: TocSidebarProps) => {
 							<a
 								data-level={heading.level}
 								href={`#${heading.slug}`}
-								className={cn("hover:underline inline-flex ", {
-									"text-base": heading.level === "two",
-									"text-sm pl-1": heading.level === "three",
-									"text-sm pl-2 text-muted-foreground":
-										heading.level === "four",
-									"text-muted-foreground text-sm pl-4":
-										heading.level === "other",
-								})}
+								className={cn(
+									"hover:underline inline-flex border-l-2 border-transparent",
+									{
+										"text-base pl-1": heading.level === "two",
+										"text-sm pl-2": heading.level === "three",
+										"text-sm pl-3 text-muted-foreground":
+											heading.level === "four",
+										"text-muted-foreground text-sm pl-4":
+											heading.level === "other",
+									},
+								)}
 							>
 								{heading.text}
 							</a>

--- a/apps/cornell/src/components/page-toc.tsx
+++ b/apps/cornell/src/components/page-toc.tsx
@@ -13,12 +13,12 @@ type TocSidebarProps = {
 export const PageToc = ({ headings }: TocSidebarProps) => {
 	return (
 		<div>
-			<p className="font-medium flex items-center">
+			<p className="font-medium flex items-center pb-5">
 				<BookmarkIcon className="mr-2 size-4" />
 				<span>ON THIS PAGE</span>
 			</p>
 
-			<ol className="max-h-[60vh] overflow-y-scroll list-disc mt-2 space-y-2 pl-4">
+			<ol className="max-h-[60vh] overflow-y-scroll list-disc mt-2 space-y-2 pl-4 list-none">
 				{headings
 					.filter((heading) => heading.level !== "other")
 					.map((heading) => (
@@ -27,8 +27,8 @@ export const PageToc = ({ headings }: TocSidebarProps) => {
 								data-level={heading.level}
 								href={`#${heading.slug}`}
 								className={cn("hover:underline inline-flex ", {
-									"text-lg": heading.level === "two",
-									"text-base pl-1": heading.level === "three",
+									"text-base": heading.level === "two",
+									"text-sm pl-1": heading.level === "three",
 									"text-sm pl-2 text-muted-foreground":
 										heading.level === "four",
 									"text-muted-foreground text-sm pl-4":

--- a/apps/cornell/src/styles/globals.css
+++ b/apps/cornell/src/styles/globals.css
@@ -4,6 +4,10 @@
 
 @import url("@itell/ui/dist/style.css");
 
+html {
+  scroll-behavior: smooth;
+}
+
 .columns .column figure:first-child,
 .columns .column figure:first-child img {
   margin-top: 0;


### PR DESCRIPTION
Adds better styling + border on heading when you are in that content chunk:
<img width="969" alt="image" src="https://github.com/learlab/itell-strapi-demo/assets/90669224/66b92797-47f2-4776-81d6-d79bd59af3b7">

Only issue is a few chunks are not included in the headers list and are therefore not rendered in the table of contents. For example, in the first chapter of the Cornell textbook, there seems to be a chunk titled Introduction that does not have a header and is therefore not in the table of contents. When scrolling through these sections, no section name has a border added: 
<img width="995" alt="image" src="https://github.com/learlab/itell-strapi-demo/assets/90669224/da8877cf-6d12-459e-b9a0-3b5e7bf07f15">
