### PR TITLE
Add devcontainer configuration file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,10 @@
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+	"runArgs": [
+		"--env-file",
+		".env"
+	],
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/joshuanianji/devcontainer-features/github-cli-persistence:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/joshuanianji/devcontainer-features/github-cli-persistence:1": {}
+	},
+	// Install pnpm package manager and use it to install dependencies.
+	"postCreateCommand": "wget -qO- https://get.pnpm.io/install.sh | ENV=$HOME/.bashrc SHELL=$(which bash) bash - && pnpm install"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store/**/*
 dist
 dist-ssr
 *.local

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
-# ITELL
+# iTELL
 
 See our documentation here: [iTELL Guide](https://learlab.org/itellguide/)
+
+## Development Instructions (using devcontainer)
+
+Dev containers are a convenient method for ensuring a completely reproducible development environment.
+
+1. Install Docker and VS Code.
+2. Install the Remote - Containers extension in VS Code.
+3. Clone this repository and open it in VS Code.
+4. Add a `.env` file to the root of the repository (speak to a team member for the contents).
+4. Use the "Reopen in Container" command.
+5. Open a new VS Code terminal (inside the container) and run `pnpm install turbo --global`.
+6. Make sure that the git repository is trusted. Use the "Git: Manage Unsafe Repositories" command.
+7. Run `turbo run dev --filter=@itell/research-methods-in-psychology` (or whichever iTELL volume/app you want to work on).


### PR DESCRIPTION
This PR adds a devcontainer configuration file that can be used to bootstrap a development environment.

Adds some brief instructions to the readme.

Tested working with `turbo run dev --filter=@itell/research-methods-in-psychology`.

`turbo build` commands are failing. I don't know if these commands work in other environments.